### PR TITLE
Shorten delays on the testStateSetGet test

### DIFF
--- a/source/Memcached-Tests/MDCacheClientTest.class.st
+++ b/source/Memcached-Tests/MDCacheClientTest.class.st
@@ -20,9 +20,10 @@ MDCacheClientTest >> serverList [
 
 { #category : #running }
 MDCacheClientTest >> testStaleSetGet [
+
 	cache remove: #testStaleSetGet.
-	cache set: #testStaleSetGet value: 'test' expires: 3 seconds.
-	4 seconds asDelay wait 
+	cache set: #testStaleSetGet value: 'test' expires: 100 milliSeconds.
+	150 milliSeconds asDelay wait 
 	"first guy should get nil, has time to reload cache".
 	self assert: (cache get: #testStaleSetGet) isNil 
 	"everyone else gets stale value allowing first guy to load from store

--- a/source/Memcached/MDCacheClient.class.st
+++ b/source/Memcached/MDCacheClient.class.st
@@ -23,7 +23,7 @@ MDCacheClient >> get: aString [
 	needsRefreshed := result second.
 	(result first < DateAndTime now and: [ needsRefreshed not ])
 		ifTrue: [ 
-			"this 0 seconds will actually be just the defaultStaleTimeout"
+			"this 0 seconds will actually be just the defaultStaleTime"
 			self
 				set: aString
 				value: result third


### PR DESCRIPTION
Couldn't change the default stale time, probably we'll be making that time configurable in the future to support stale-while-revalidate cache policy